### PR TITLE
add workflows to add PRs to merge queue and close open PRs

### DIFF
--- a/.github/workflows/add-prs-to-q.yml
+++ b/.github/workflows/add-prs-to-q.yml
@@ -1,0 +1,20 @@
+name: Action - Add PRs To Queue
+on:
+  workflow_dispatch:
+
+jobs:
+  add-prs-to-queue:
+    name: Add PRs To Queue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Add all open PRs to merge queue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+            gh pr merge "$pr"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       pr_number: ${{ steps.set-result.outputs.result || github.event.pull_request.number }}
     steps:
     - if: github.event_name == 'merge_group'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       id: set-result
       env:
         REF: ${{ github.ref }}
@@ -37,7 +37,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Get repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
       - id: get_commit_message

--- a/.github/workflows/close-open-prs.yml
+++ b/.github/workflows/close-open-prs.yml
@@ -1,0 +1,20 @@
+name: Action - Close Open PRs
+on:
+  workflow_dispatch:
+
+jobs:
+  close-open-prs:
+    name: Close Open PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Close all open PRs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+            gh pr close "$pr" --delete-branch
+          done

--- a/.github/workflows/demo-bad-prs.yml
+++ b/.github/workflows/demo-bad-prs.yml
@@ -1,4 +1,4 @@
-name: Open Bad PRs
+name: Action - Open Bad PRs
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +13,7 @@ jobs:
     name: Get File Names
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         id: file_name
         with:
           result-encoding: string
@@ -32,11 +32,11 @@ jobs:
         file_content: ['Hello World!']
         commit_message: ['fail']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - id: create-pr
-      uses: austenstone/merge-queue-demo/.github/actions/create-pr@main
+      uses: ./.github/actions/create-pr
       with:
         file_name: ${{ matrix.file_name }}
         file_content: ${{ matrix.file_content }}
-        token: ${{ secrets.AUSTEN_PAT }}
+        token: ${{ secrets.USER_PAT }}
         commit_message: ${{ matrix.commit_message }}

--- a/.github/workflows/demo-conflict-pr.yml
+++ b/.github/workflows/demo-conflict-pr.yml
@@ -1,4 +1,4 @@
-name: Merge Conflict PRs
+name: Action - Merge Conflict PRs
 on:
   workflow_dispatch:
 
@@ -7,7 +7,7 @@ jobs:
     name: Get Date/Time
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         id: date_time
         with:
           result-encoding: string
@@ -25,13 +25,13 @@ jobs:
         file_name: ['File1.txt']
         file_content: ['Hello World! ${{ needs.get_date_time.outputs.date_time }}', 'Hello Mars! ${{ needs.get_date_time.outputs.date_time }}']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - id: create-pr
-      uses: austenstone/merge-queue-demo/.github/actions/create-pr@main
+      uses: ./.github/actions/create-pr
       with:
         file_name: ${{ matrix.file_name }}
         file_content: ${{ matrix.file_content }}
-        token: ${{ secrets.AUSTEN_PAT }}
+        token: ${{ secrets.USER_PAT }}
     - run: gh pr merge ${{ steps.create-pr.outputs.pr_number }} --merge --auto
       env:
-        GH_TOKEN: ${{ secrets.AUSTEN_PAT }}
+        GH_TOKEN: ${{ secrets.USER_PAT }}

--- a/.github/workflows/demo-good-prs.yml
+++ b/.github/workflows/demo-good-prs.yml
@@ -1,4 +1,4 @@
-name: Open Good PRs
+name: Action - Open Good PRs
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +13,7 @@ jobs:
     name: Get File Names
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         id: file_name
         with:
           result-encoding: string
@@ -31,10 +31,10 @@ jobs:
         file_name: ${{ fromJSON(needs.file_name.outputs.file_name) }}
         file_content: ['Hello World!']
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - id: create-pr
-      uses: austenstone/merge-queue-demo/.github/actions/create-pr@main
+      uses: ./.github/actions/create-pr
       with:
         file_name: ${{ matrix.file_name }}
         file_content: ${{ matrix.file_content }}
-        token: ${{ secrets.AUSTEN_PAT }}
+        token: ${{ secrets.USER_PAT }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This project was made for demoing GitHub Merge Queue. Go run the Actions to create pull requests that will pass or fail checks in the merge queue.
 
+## Getting Started
+1. Clone this repository.
+2. Push it to your own GitHub organization.
+3. Create a repository secret named `USER_PAT`.
+	If you use a classic PAT, give it the `repo` scope.
+	If you use a fine-grained PAT, grant it access to this repository with:
+	`Contents: Read and write`
+	`Pull requests: Read and write`
+4. Use the actions workflows to create PRs that will pass or fail checks in the merge queue, add PRs to the merge queue, and close open PRs.
+
+`USER_PAT` is used by the PR creation workflows to push branches and create pull requests, and by the merge conflict demo workflow to merge a PR into the merge queue.
+
 ## Actions
 
 ### Open Bad PRs
@@ -13,7 +25,12 @@ Opens X number of PRs that will pass checks and pass checks in the merge queue.
 ### Merge Conflict PRs
 Opens 2 PRs that will pass checks but conflict with each other in the merge queue.
 
+### Add Prs to Queue
+Adds all open PRs to the merge queue.
+
+### Close Open PRs
+Closes all open PRs.
+
 ## Resources
 * [Managing a merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
 * [Merging a pull request with a merge queue](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue)
-* 


### PR DESCRIPTION
This pull request adds two new workflows for managing pull requests in bulk. 
1. Adds all open PRs to the merge queue
2. Closes all open PRs

I have also updated the version of actions in the workflows, and renamed `AUSTEN_PAT` to `USER_PAT`.

Additionally, I've added details about `USER_PAT` to the README.